### PR TITLE
Add a double underscore before backup date

### DIFF
--- a/DraftsBackupScript/BackupDrafts.py
+++ b/DraftsBackupScript/BackupDrafts.py
@@ -56,7 +56,7 @@ def backup_file(dir_path, file_name):
 
     backup_dir_path = '{}\\{}'.format(dir_path, BACKUP_FLDR)
     date = datetime.datetime.today().strftime('%Y-%m-%d')
-    backup_name = '{}_{}.{}'.format(file_name.split('.')[0], date, file_name.split('.')[1])
+    backup_name = '{}__{}.{}'.format(file_name.split('.')[0], date, file_name.split('.')[1])
     original_file_path = '{}\\{}'.format(dir_path, file_name)
     backup_file_path = '{}\\{}'.format(backup_dir_path, backup_name)
 


### PR DESCRIPTION
to make the automatic datestamp easily differentiable from existing
dates in file names (Per Srikant's Request)

(Super simple change, shouldn't need further review.)